### PR TITLE
Simplifies deployment

### DIFF
--- a/product/uppercut/template.builder/TemplateBuilder.cs
+++ b/product/uppercut/template.builder/TemplateBuilder.cs
@@ -101,7 +101,7 @@ namespace uppercut.template.builder
                                                                          destination_directory,
                                                                          use_environment_subdirectory ? "\\" + settings_name: string.Empty);
                             file_system.verify_or_create_directory(destination_file_path);
-                            copy_file(file_name, String.Format("{0}\\{1}.{2}",destination_file_path,settings_name,destination_file_name));
+                            copy_file(file_name, String.Format("{0}\\{1}{2}", destination_file_path, use_environment_subdirectory ? string.Empty : settings_name + ".", destination_file_name));
                         }
                     }
                 }


### PR DESCRIPTION
Adding local/production to filenames already in a folder named local/production seems a bit redundant.

This way you can take all the files in a specific environment folder and just put them somewhere without having to remove the suffixes...
