### PR TITLE
file_is_for_settings method depends on filenames starting with environment string

### DIFF
--- a/product/uppercut/template.builder/TemplateBuilder.cs
+++ b/product/uppercut/template.builder/TemplateBuilder.cs
@@ -101,7 +101,7 @@ namespace uppercut.template.builder
                                                                          destination_directory,
                                                                          use_environment_subdirectory ? "\\" + settings_name: string.Empty);
                             file_system.verify_or_create_directory(destination_file_path);
-                            copy_file(file_name, String.Format("{0}\\{1}{2}", destination_file_path, use_environment_subdirectory ? string.Empty : settings_name + ".", destination_file_name));
+                            copy_file(file_name, String.Format("{0}\\{1}.{2}",destination_file_path,settings_name,destination_file_name));
                         }
                     }
                 }


### PR DESCRIPTION
Revert "When moving files to environment.files do not add environment label to filenames if a specific environment subfolder is being used"

This reverts commit 1e6e55bad3055d2d956a27d2bd46f0b06c33f30b.

file_is_for_settings method depends on filenames starting with environment string
