### PR TITLE
Implement xml content as value in settings

### DIFF
--- a/product/uppercut.tests/template.builder/EnvironmentDictionarySpecs.cs
+++ b/product/uppercut.tests/template.builder/EnvironmentDictionarySpecs.cs
@@ -376,6 +376,12 @@ namespace uppercut.tests.template.builder
             {
                 Assert.AreEqual(@"""somevalue""", result["${settings.with.quote}"]);
             }
+            
+            [Observation]
+            public void should_read_property_xml()
+            {
+                Assert.AreEqual(@"<xmlParent><child num=""1"" /><child num=""2"" /></xmlParent>", result[@"${settings.with.xml}"]);
+            }
     
         }
   

--- a/product/uppercut.tests/template.builder/settings/DevTokenSettings.cs
+++ b/product/uppercut.tests/template.builder/settings/DevTokenSettings.cs
@@ -12,6 +12,13 @@
     <property name=""settings.no.separation"" value=""${server.files}${environment}"" />
     <property name=""settings.with.nonexisting"" value=""${server.files}\${nonexistant.setting}"" />
     <property name=""settings.with.quote"" value=""${quote}somevalue${quote}"" />
+
+    <property name=""settings.with.xml"">
+        <xmlParent>
+            <child num=""1"" />
+            <child num=""2"" />
+        </xmlParent>
+    </property>
     
 </project>";
     }


### PR DESCRIPTION
Allows using xml in propertys like:

```
<project>
    <propery name="regular.usage" value="simple property value" />
    <property name="settings.with.xml">
        <xmlParent>
            <child num="1" />
            <child num="2" />
        </xmlParent>
    </property>
</project>
```
